### PR TITLE
common 1.4.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
-## 현재버전 1.3.1
+## 현재버전 1.4.0
+
+## [1.4.0] - 2025-04-15
+
+### Added
+- `@NoAuthFeignClient` 커스텀 어노테이션 도입
+    - 인증 정보가 불필요한 FeignClient (예: 회원가입, 로그인, 외부 API 등)에 명시적으로 선언
+    - 불필요한 헤더 전송을 방지하여 보안성과 명확한 책임 분리 확보
+
+- `FeignInterceptor` 자동 구성 기능 추가
+    - 내부 API 요청에만 `X-User-Id`, `X-User-Role` 헤더를 자동으로 포함
+    - `@NoAuthFeignClient` 어노테이션이 붙은 경우 헤더 전송을 생략하도록 분기 처리
+    - Spring Boot 3 기준 `AutoConfiguration.imports` 등록 방식 사용
 
 ## [1.3.1] - 2025-04-15
 
@@ -14,14 +26,14 @@
 ### Added
 - `@AuthenticatedUser` 어노테이션 및 `AuthenticatedUserArgumentResolver` 구현
     - `HttpServletRequest`의 `X-User-Id` 헤더 값을 자동 주입하는 ArgumentResolver 구현
-    - 공통 모듈에서 WebMvcConfigurer를 통해 등록 가능하도록 구성
+  - Spring Boot 3 기준 `AutoConfiguration.imports` 등록 방식 사용
 
 - `@RoleCheck` 어노테이션 및 AOP 기반 인가 처리 (`RoleCheckAspect`)
     - 메서드 단위로 역할(Role)에 따른 인가 제어 가능
     - 헤더 기반 권한 정보(`X-User-Role`)를 기준으로 비교
 
 - `RoleCheckAopConfig` / `AuthenticatedUserConfig` 설정 클래스
-    - 공통 모듈에서 등록을 위해 `@AutoConfiguration` 기반으로 분리 구성
+    - Spring Boot 3 기준 `AutoConfiguration.imports` 등록 방식 사용
   
 - `UserInfo` DTO 추가
     - 인증된 사용자 정보를 담기 위한 공용 데이터 클래스 (확장 가능 구조)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 
 - AuthenticatedUserArgumentResolver 통해 커스텀 인자 주입 처리
 
-- @AutoConfiguration 기반으로 서비스에서 따로 설정 없이 적용 가능
+- **자동 구성(AutoConfiguration.imports)**을 통해 별도 설정 없이 사용 가능합니다.
 ```
   @GetMapping("/me")
   public ResponseEntity<?> me(@AuthenticatedUser UserInfo user) {
@@ -87,6 +87,29 @@ public String adminOnly() {
 }
 ```
 
+## 🌐 FeignClient 인증 헤더 자동 삽입
+- 내부 API 호출 시, Feign 요청에 자동으로 X-User-Id, X-User-Role 헤더가 추가됩니다.
+
+- 공통 모듈에 포함된 FeignInterceptor가 이를 자동 처리하며,
+- **자동 구성(AutoConfiguration.imports)**을 통해 별도 설정 없이 사용 가능합니다.
+
+## ✅ 인증이 필요 없는 요청 처리
+- 회원가입, 로그인, 외부 API 요청 등 인증 정보가 불필요한 FeignClient는
+- 아래처럼 @NoAuthFeignClient 어노테이션을 선언하면 헤더가 붙지 않습니다.
+
+```
+@FeignClient(name = "authClient", url = "${auth.url}")
+@NoAuthFeignClient
+public interface AuthClient {
+
+    @PostMapping("/login")
+    TokenResponse login(LoginRequest request);
+
+    @PostMapping("/sign-up")
+    void signUp(SignUpRequest request);
+}
+```
+
 ## ⚙️ 사용법
 
 ### 1. 의존성 추가 (서비스 프로젝트의 `build.gradle`)
@@ -104,7 +127,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fourirbnb:common:1.3.1'
+    implementation 'com.fourirbnb:common:1.4.0'
 }
 ```
 
@@ -121,7 +144,7 @@ gpr.key=YOUR_PERSONAL_ACCESS_TOKEN
 
 ```bash
 ./gradlew publish
-jar tf build/libs/common-1.3.1.jar  # JAR 파일 내 클래스 확인
+jar tf build/libs/common-1.4.0.jar  # JAR 파일 내 클래스 확인
 ```
 
 ---

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.fourirbnb'
-version = '1.3.1'
+version = '1.4.0'
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_17
@@ -44,6 +44,8 @@ dependencies {
 	implementation 'org.springframework:spring-webmvc:6.2.5'
 	implementation 'org.springframework:spring-aop:6.2.5'
 	implementation 'org.aspectj:aspectjweaver:1.9.24'
+	//feign
+	implementation 'io.github.openfeign:feign-core:12.4'
 }
 
 publishing {

--- a/src/main/java/com/fourirbnb/common/FeignInterceptor/NoAuthFeignClient.java
+++ b/src/main/java/com/fourirbnb/common/FeignInterceptor/NoAuthFeignClient.java
@@ -1,0 +1,12 @@
+package com.fourirbnb.common.FeignInterceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoAuthFeignClient {
+
+}

--- a/src/main/java/com/fourirbnb/common/config/FeignInterceptorConfig.java
+++ b/src/main/java/com/fourirbnb/common/config/FeignInterceptorConfig.java
@@ -1,0 +1,39 @@
+package com.fourirbnb.common.config;
+
+import com.fourirbnb.common.FeignInterceptor.NoAuthFeignClient;
+import com.fourirbnb.common.exception.UnauthorizedAccessException;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignInterceptorConfig implements RequestInterceptor {
+
+
+  @Override
+  public void apply(RequestTemplate requestTemplate) {
+    //클래스 추출
+    Class<?> clazz = requestTemplate.feignTarget().type();
+
+    //클래스 내 해당 Annotation 존재시 true - 외부 API
+    if(clazz.isAnnotationPresent(NoAuthFeignClient.class)){
+      return;
+    }
+
+    //내부 api 시 헤더추가 - Annotation X
+    ServletRequestAttributes attrs =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+    if (attrs == null) {
+      throw new UnauthorizedAccessException("인증정보 없음");
+    }
+    HttpServletRequest request = attrs.getRequest();
+    String userId=request.getHeader("X-User-Id");
+    String role=request.getHeader("X-User-Role");
+    requestTemplate.header("X-User-Id", userId);
+    requestTemplate.header("X-User-Role", role);
+  }
+}

--- a/src/main/java/com/fourirbnb/common/config/RoleCheckAopConfig.java
+++ b/src/main/java/com/fourirbnb/common/config/RoleCheckAopConfig.java
@@ -18,7 +18,8 @@ public class RoleCheckAopConfig {
   @Around("@annotation(roleCheck)")
   public Object checkRole(ProceedingJoinPoint joinPoint, RoleCheck roleCheck) throws Throwable {
     //AOP RequestContextHolder
-    ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    ServletRequestAttributes attrs =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 
     if (attrs == null) {
       throw new UnauthorizedAccessException("인증정보 없음");

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 com.fourirbnb.common.config.JpaConfig
 com.fourirbnb.common.config.AuthenticatedUserConfig
 com.fourirbnb.common.config.RoleCheckAopConfig
+com.fourirbnb.common.config.FeignInterceptorConfig


### PR DESCRIPTION
- '@NoAuthFeignClient' 커스텀 어노테이션 도입 - 인증이 불필요한 FeignClient 요청에 대한 헤더 생략 처리
- FeignInterceptor 자동 구성 추가 - 내부 API 요청에 한해 'X-User-Id', 'X-User-Role' 헤더 자동 삽입